### PR TITLE
Remove unused css files from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,6 @@ CHAPTERS := sources/chapter1.md \
 
 # All style files you're using.
 STYLES := css/tufte.css \
-          css/pandoc.css \
-          css/pandoc-solarized.css \
           css/numenvs.css \
           css/navbar.css \
           css/frontpage.css \


### PR DESCRIPTION
Code at HEAD reports error `make: *** No rule to make target `css/pandoc.css', needed by `publish/style.css'.  Stop.`