### PR TITLE
Make compatible with pandoc 2.5+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,6 @@ publish/%.html: sources/%.md templates/tufte.html5 Makefile $(FILTERS) reference
 	pandoc templates/shared-macros.tex $< \
     --to html5 \
     --katex \
-    --citeproc \
     --template templates/tufte.html5 \
     --csl=templates/chicago-fullnote-bibliography.csl \
     --metadata link-citations=false \
@@ -98,7 +97,6 @@ publish/index.html: sources/index.md templates/index.html5 Makefile $(FILTERS)
 ## Rule to create individual PDF chapters from markdown
 publish/pdf/%.pdf: sources/%.md templates/book.tex Makefile $(FILTERS) references.bib templates/shared-macros.tex
 	pandoc $< \
-    --citeproc \
     --bibliography=references.bib \
     --csl=templates/chicago-fullnote-bibliography.csl \
     --metadata link-citations=false \
@@ -130,7 +128,6 @@ publish/pdf/$(bookfilename).pdf: $(CHAPTERS) templates/book.tex templates/refere
       --id-prefix=$(notdir $(chapter)) \
       --output tmp-$(notdir $(chapter));) \
     pandoc \
-    --citeproc \
     --bibliography=references.bib \
     --csl=templates/chicago-fullnote-bibliography.csl \
     --metadata link-citations=false \

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Find the compiled results in `publish/` directory.
 
 - `pandoc` 2.5+
 - `pandoc-citeproc` 0.15+
-- `python` 3.5 or higher with `pandocfilters` installed
+- `python` 3.5 or higher
 - For generating PDFs, you'll need `pdflatex`, which usually ships with LaTeX distributions.
 
 Note: Every new release of `pandoc` since version 2.10 has broken the compile process due to changes in the way that pandoc handles citations. Getting things to run with a different version of `pandoc` is certainly possible, but may require changes, primarily to the latex template located at `templates/book.tex`. The issue is typically with the latex environments related to `cslreferences`. Copy and paste from the latex template corresponding to your pandoc version as is necessary.  

--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ Features:
 ## Getting started
 
 1. Install [pandoc](https://pandoc.org/) **v2.14** (exact version requirement)
-2. Make sure you have python 3.5+ installed with [pandocfilters](https://github.com/jgm/pandocfilters) package
-3. Clone the repository
-4. Customize your book by setting up variables in `Makefile`.
-5. Type `make` to build both pdf and html files.
+2. Make sure you have python 3.5+ installed. 
+3. Clone the repository.
+4. Install dependencies with `pip3 install -r requirements.txt`.
+5. Customize your book by setting up variables in `Makefile`.
+6. Type `make` to build both pdf and html files.
   - To build html only, type `make html`.
   - To build pdf only, type `make pdf`.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Features:
 
 ## Getting started
 
-1. Install [pandoc](https://pandoc.org/) **v2.14** (exact version requirement)
+1. Install [pandoc](https://pandoc.org/) 2.5+.
 2. Make sure you have python 3.5+ installed with [pandocfilters](https://github.com/jgm/pandocfilters) package
 3. Clone the repository
 4. Customize your book by setting up variables in `Makefile`.
@@ -29,8 +29,10 @@ Find the compiled results in `publish/` directory.
 
 ## Dependencies
 
-- `pandoc` 2.14 (**strict: must be version 2.14**)
+- `pandoc` 2.5+
+- `pandoc-citeproc` 0.15+
 - `python` 3.5 or higher with `pandocfilters` installed
+- For generating PDFs, you'll need `pdflatex`, which usually ships with LaTeX distributions.
 
 Note: Every new release of `pandoc` since version 2.10 has broken the compile process due to changes in the way that pandoc handles citations. Getting things to run with a different version of `pandoc` is certainly possible, but may require changes, primarily to the latex template located at `templates/book.tex`. The issue is typically with the latex environments related to `cslreferences`. Copy and paste from the latex template corresponding to your pandoc version as is necessary.  
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pandocfilters==1.4.3


### PR DESCRIPTION
This PR makes unbuch compatible with pandoc 2.5+, which now uses `pandoc-citeproc` by default.

Minor changes:
- This PR more specifically lists dependencies on LaTeX tools.
- This PR adds a `requirements.txt`, which simplifies installation directions somewhat. This also makes it easier to update dependencies in the future, or to specify particular versions, without having to keep the README in sync.